### PR TITLE
Add struct formatting.

### DIFF
--- a/corpus/function-struct.spicy
+++ b/corpus/function-struct.spicy
@@ -1,0 +1,12 @@
+# This formatted strangely, include a separate test.
+module X;
+
+function f(): uint32 {
+  return 42;
+}
+
+
+type Shape = struct {
+  height: uint8;
+  width: uint8;
+};

--- a/corpus/function-struct.spicy.expected
+++ b/corpus/function-struct.spicy.expected
@@ -1,0 +1,11 @@
+# This formatted strangely, include a separate test.
+module X;
+
+function f(): uint32 {
+    return 42;
+}
+
+type Shape = struct {
+    height: uint8;
+    width: uint8;
+};

--- a/corpus/struct.spicy
+++ b/corpus/struct.spicy
@@ -1,0 +1,25 @@
+module X;
+
+type Shape=struct{
+height: uint8;
+width: uint8;
+};
+
+
+
+
+type Circle =      struct     {
+  diameter: uint8;
+};
+type SticksToCircle = struct {
+diameter:uint8;
+};
+
+
+
+
+
+type MoveCloser = struct
+{
+a:uint8;b:uint8;c:uint8;
+    };

--- a/corpus/struct.spicy.expected
+++ b/corpus/struct.spicy.expected
@@ -1,0 +1,19 @@
+module X;
+
+type Shape = struct {
+    height: uint8;
+    width: uint8;
+};
+
+type Circle = struct {
+    diameter: uint8;
+};
+type SticksToCircle = struct {
+    diameter: uint8;
+};
+
+type MoveCloser = struct {
+    a: uint8;
+    b: uint8;
+    c: uint8;
+};

--- a/src/query.scm
+++ b/src/query.scm
@@ -44,6 +44,16 @@
   (comment)? @do_nothing
 )
 
+("struct"
+ [
+  (field_decl)
+ ] @append_empty_softline
+  .
+  (comment)? @do_nothing
+)
+
+(struct_decl "struct" @append_space)
+
 (unit_switch
   "switch" @append_space
 )
@@ -161,6 +171,7 @@
  (type_decl)
  (field_decl)
  (unit_switch)
+ (struct_decl)
  (sink_decl)
  (hook_decl)
  (function_decl)
@@ -174,6 +185,7 @@
 [
  (enum_decl)
  (type_decl)
+ (function_decl)
 ]
  @append_hardline
 


### PR DESCRIPTION
The spicy-quic parser uses a struct type and the formatting didn't look quite right. Also, formatting functions and structs together ended-up looking like:

    module X;
    function f(): uint32 {
        return 42;
    } type Shape = struct{
        height: uint8; width: uint8;
    };