### PR TITLE
Add struct formatting.

### DIFF
--- a/corpus/function.spicy
+++ b/corpus/function.spicy
@@ -27,3 +27,6 @@ time(0));
 # Map ctor.
 map(1: b"");
 map<uint8, bytes>(1: b"");
+
+function f() {}
+function f() {}

--- a/corpus/function.spicy.expected
+++ b/corpus/function.spicy.expected
@@ -30,3 +30,6 @@ spicy::strftime(
 # Map ctor.
 map(1: b"");
 map<uint8, bytes>(1: b"");
+
+function f() {}
+function f() {}

--- a/corpus/struct.spicy
+++ b/corpus/struct.spicy
@@ -1,0 +1,27 @@
+module X;
+
+type Shape=struct{
+height: uint8;
+width: uint8;
+};
+
+
+
+
+type Circle =      struct     {
+  diameter: uint8;
+};
+type SticksToCircle = struct {
+diameter:uint8;
+};
+
+
+
+
+
+type MoveCloser = struct
+{
+a:uint8;b:uint8;c:uint8;
+    };
+
+type X = struct {x: uint8;};

--- a/corpus/struct.spicy.expected
+++ b/corpus/struct.spicy.expected
@@ -1,0 +1,21 @@
+module X;
+
+type Shape = struct {
+    height: uint8;
+    width: uint8;
+};
+
+type Circle = struct {
+    diameter: uint8;
+};
+type SticksToCircle = struct {
+    diameter: uint8;
+};
+
+type MoveCloser = struct {
+    a: uint8;
+    b: uint8;
+    c: uint8;
+};
+
+type X = struct { x: uint8; };

--- a/src/query.scm
+++ b/src/query.scm
@@ -44,6 +44,14 @@
   (comment)? @do_nothing
 )
 
+("struct"
+ (field_decl) @append_empty_softline
+  .
+  (comment)? @do_nothing
+)
+
+(struct_decl "struct" @append_space)
+
 (unit_switch
   "switch" @append_space
 )
@@ -161,6 +169,7 @@
  (type_decl)
  (field_decl)
  (unit_switch)
+ (struct_decl)
  (sink_decl)
  (hook_decl)
  (function_decl)
@@ -174,6 +183,8 @@
 [
  (enum_decl)
  (type_decl)
+ (function_decl)
+ (struct_decl)
 ]
  @append_hardline
 


### PR DESCRIPTION
The spicy-quic parser uses a struct type and the formatting didn't look quite right. Also, formatting functions and structs together ended-up looking like:

    module X;
    function f(): uint32 {
        return 42;
    } type Shape = struct{
        height: uint8; width: uint8;
    };