### PR TITLE
Bump tree-sitter-spicy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-spicy"
 version = "0.0.1"
-source = "git+https://github.com/bbannier/tree-sitter-spicy#adf74b7167613c8c9769841f0df761380b925cd1"
+source = "git+https://github.com/bbannier/tree-sitter-spicy#9db4b94c30c34d0cea3e742f303633ff94966cde"
 dependencies = [
  "cc",
  "tree-sitter 0.20.10",

--- a/corpus/function.spicy
+++ b/corpus/function.spicy
@@ -30,3 +30,6 @@ map<uint8, bytes>(1: b"");
 
 function f() {}
 function f() {}
+
+# Declaration with templated arg type. This checks that we always leave a space between `>` and `=`.
+public function file_data_in(data: bytes, fid: optional<string> = Null): void &cxxname="zeek::spicy::rt::file_data_in";

--- a/corpus/function.spicy.expected
+++ b/corpus/function.spicy.expected
@@ -36,3 +36,6 @@ map<uint8, bytes>(1: b"");
 
 function f() {}
 function f() {}
+
+# Declaration with templated arg type. This checks that we always leave a space between `>` and `=`.
+public function file_data_in(data: bytes, fid: optional<string> = Null): void &cxxname="zeek::spicy::rt::file_data_in";


### PR DESCRIPTION
This brings in support for function arg default values. We previously didn't parse such values at all (resulting in tree-sitter ERROR nodes), but we would also just leave them alone unless invoked with `--reject-parse-errors`. The recent parsing updates around parameterized types changed what we could parse here and now would format data, leading us to incorrectly remove a required space.

With this patch we can now parse function arg default values. We keep the space since we already enforce spaces around `=`. To be sure, we added a baseline.