### PR TITLE
Fix syntax error in test baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: gitlint
   - repo: https://github.com/crate-ci/typos
-    rev: v1.21.0
+    rev: v1.22.7
     hooks:
       - id: typos
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/corpus/preprocessor.spicy
+++ b/corpus/preprocessor.spicy
@@ -24,8 +24,9 @@
 1;
 @endif
 
-# FIXME(bbannier): Empty lines in bodies are currently not removed.
-@if
+
+
+@if 1
 
 @else
 

--- a/corpus/preprocessor.spicy.expected
+++ b/corpus/preprocessor.spicy.expected
@@ -20,11 +20,8 @@
 1;
 @endif
 
-# FIXME(bbannier): Empty lines in bodies are currently not removed.
-@if
-
+@if 1
 @else
-
 @endif
 
 # We allow constructs like `import` in preprocessor macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ mod test {
                     o.join(file_name)
                 };
 
-                let formatted = format(&input, false, true).expect(&format!(
+                let formatted = format(&input, false, false).expect(&format!(
                     "cannot format source file {}",
                     t.path().to_string_lossy()
                 ));


### PR DESCRIPTION
Turns out the reason we did not format this case was that the syntax was
incorrect (`@if` requires an expression). The reason this slipped by was
that we previously ignored parse errors in the test corpus.