### PR TITLE
Remove duplicate rule for field_decl

### DIFF
--- a/corpus/unit.spicy
+++ b/corpus/unit.spicy
@@ -1,5 +1,12 @@
 type Foo = unit { a: uint8; b: bytes &eod; c: /re/;};
 
+# Regression test for #192.
+public type Bar = unit {
+    a: uint64;
+
+    on %done { print self; }
+};
+
 type Z = unit {
 var a: uint8;
 };

--- a/corpus/unit.spicy.expected
+++ b/corpus/unit.spicy.expected
@@ -4,6 +4,15 @@ type Foo = unit {
     c: /re/;
 };
 
+# Regression test for #192.
+public type Bar = unit {
+    a: uint64;
+
+    on %done {
+        print self;
+    }
+};
+
 type Z = unit {
     var a: uint8;
 };

--- a/src/query.scm
+++ b/src/query.scm
@@ -43,13 +43,14 @@
   "}" @prepend_indent_end @prepend_hardline
 )
 
-(
+(type_decl
   "unit"
   [
     (field_decl)
+    (var_decl)
     (sink_decl)
     (unit_switch)
-  ] @append_empty_softline
+  ] @append_hardline
   .
   (comment)? @do_nothing
 )
@@ -324,15 +325,6 @@
 )
 (module
   (var_decl) @append_hardline
-  .
-  (comment)? @do_nothing
-)
-(type_decl
-  "unit"
-  [
-   (field_decl ";")
-   (var_decl)
-  ] @append_hardline
   .
   (comment)? @do_nothing
 )


### PR DESCRIPTION
We previously had two rules handline a `field_decl` in a unit, one inserting a hardline and one a empty softline; this lead to us inserting an extraneous space.

Closes #192.