### PR TITLE
Unbreak building without `--locked` due to prettydiff semver breakage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: gitlint
   - repo: https://github.com/crate-ci/typos
-    rev: v1.36.3
+    rev: v1.38.1
     hooks:
       - id: typos
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "filetime",
  "miette",
  "pretty_assertions",
+ "prettydiff",
  "rayon",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ rayon = "1.11.0"
 topiary-core = { version = "0.6.1", default-features = false }
 topiary-tree-sitter-facade = { version = "0.6.2", default-features = false }
 
+# # Pin a dependency of topiary-core. We need this since
+# prettydiff broke semver with prettydiff-0.8.2, see
+# https://github.com/oli-obk/prettydiff/issues/28.
+prettydiff = { version = "=0.8.1", default-features = false }
+
 [dev-dependencies]
 assert_cmd = { version = "2.0.17", default-features = false }
 filetime = { version = "0.2.26", default-features = false }


### PR DESCRIPTION
prettydiff-0.8.2 broke semver, so building without lock files is broken, see https://github.com/oli-obk/prettydiff/issues/28. We need this to support pre-commit which refuses to use `--locked` when installing Rust dependencies, see https://github.com/pre-commit/pre-commit/issues/3162.